### PR TITLE
edgecase sizeType validation fix

### DIFF
--- a/excercises/2-props/solution.js
+++ b/excercises/2-props/solution.js
@@ -17,9 +17,22 @@ var emailType = (props, propName, componentName) => {
   );
 };
 
+function validateSize(inputValue) {
+  if (Number.isInteger(inputValue)) {
+    return true;
+  }
+  
+  if (typeof inputValue === 'string') {
+    let number = parseInt(inputValue);
+    return ((number + "") === inputValue);
+  }
+  
+  return false;
+}
+
 var sizeType = (props, propName, componentName) => {
   warning(
-    !isNaN(parseInt(props[propName])),
+    validateSize(props.size),
     `Invalid prop "${propName}", can't convert "${props[propName]}" to number. Check the render method of "${componentName}".`
   );
 };


### PR DESCRIPTION
sizeType validation does not work for inputs that start with number and are followed by string.
Example : "32janjks", "3ab4"